### PR TITLE
ヘッダーのtabレイアウトを追加

### DIFF
--- a/css/stylesheet.css
+++ b/css/stylesheet.css
@@ -1,11 +1,7 @@
 /* ==========================================================================
     ヘッダー
     ========================================================================== */
-/* PC */
-@media (min-width: 960px) {
-
-}
-
+    
 .l-header {
     height: 80px;
     width: 100%;
@@ -37,7 +33,130 @@
     transition: all 0.3s;
 }
 
+/* PC */
+@media (min-width: 960px) {
+    #l-header__show-menu,
+    #l-header__hide-menu,
+    #l-header__cover {
+        display: none;
+    }
+}
 
+/* Tab */
+@media (min-width: 560px) and (max-width: 959px) {
+    .l-header nav {
+        display: block;
+        width: 220px;
+        height: 100vh;
+        z-index: 20;
+        text-align: center;
+        background-color: #333;
+    }
+
+    #l-header__hide-menu {
+        color: #fff;
+        font-size: 1.5rem;
+        margin-top: 1.5rem;
+        margin-right: 2rem;
+        display: block;
+        float: right;
+        cursor: pointer;
+    }
+
+    .l-header__menu ul {
+        display: block;
+        margin-top: 80px;
+        padding-right: 0;
+    }
+
+    .l-header__menu li {
+        height: 50px;
+        line-height: 50px;
+    }
+
+    .l-header__menu ul a {
+        color: #fff;
+    }
+
+    #l-header__cover {
+        background-color: #071561;
+        opacity: 0.6;
+        width: 100%;
+        height: 100vh;
+        position: absolute;
+        top: -100vh;
+        left: 0;
+        z-index: 10;
+        transition: all .2s;
+    }
+    
+    /* ドロワーメニューがオープンの場合 */
+    .l-header__menu-open .l-header nav {
+        position: absolute;
+        top: 0;
+        right: 0;
+        transition: .3s;
+    }
+    
+    .l-header__menu-open #l-header__show-menu {
+        display: none;
+    }
+
+    .l-header__menu-open #l-header__cover {
+        position: absolute;
+        top: 0;
+        transition: .2s;
+    }
+
+    /* ドロワーメニューがクローズの場合 */
+    .l-header nav {
+        position: absolute;
+        top: 0;
+        right: -220px;
+        transition: .3s;
+    }
+
+    #l-header__show-menu {
+        position: relative;
+        top: 17px;
+        right: 10px;
+        width: 50px;
+        height: 50px;
+        cursor: pointer;
+    }
+
+    .l-header__show-menu-line {
+        position: relative;
+        top: 25px;
+        right: -15px;
+        width: 28px;
+        height: 3px;
+        color: #0624c9;
+        background: #0624c9;
+        cursor: pointer;
+    }
+
+    .l-header__show-menu-line::before {
+        text-align: right;
+        content: "";
+        position: absolute;
+        top: -10px;
+        right: 0;
+        width: 130%;
+        height: 100%;
+        background: #0624c9;
+    }
+    
+    .l-header__show-menu-line::after {
+        content: "";
+        position: absolute;
+        top: 10px;
+        right: 0;
+        width: 70%;
+        height: 100%;
+        background: #0624c9;
+    }
+}
 /* ==========================================================================
     メインビジュアル
     ========================================================================== */

--- a/css/stylesheet.css
+++ b/css/stylesheet.css
@@ -42,8 +42,8 @@
     }
 }
 
-/* Tab */
-@media (min-width: 560px) and (max-width: 959px) {
+/* Tab, SP */
+@media (max-width: 959px) {
     .l-header nav {
         display: block;
         width: 220px;
@@ -79,7 +79,7 @@
     }
 
     #l-header__cover {
-        background-color: #071561;
+        background-color: #eee;
         opacity: 0.6;
         width: 100%;
         height: 100vh;

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
         <header class="l-header">
             <a href="index.html"><img src="image/logo_header.svg" class="l-header__logo" alt="ヘッダーロゴ"></a>
             <nav class="l-header__menu">
+                <p id="l-header__hide-menu">✕</p>
                 <ul>
                     <li><a href="index.html">Home</a></li>
                     <li><a href="#">Concept</a></li>
@@ -21,6 +22,10 @@
                     <li><a href="#">Access</a></li>
                 </ul>
             </nav>
+            <div id="l-header__show-menu">
+                <div class="l-header__show-menu-line"></div>
+            </div>
+            <div id="l-header__cover"></div>
         </header>
         
         <article class="p-mainVisual">

--- a/script.js
+++ b/script.js
@@ -1,8 +1,19 @@
 'use strict'
 {
-  
+  const body = document.querySelector('body');
+  const show = document.getElementById('l-header__show-menu');
+  const hide = document.getElementById('l-header__hide-menu');
+  const cover = document.getElementById('l-header__cover');
 
+  show.addEventListener('click', () => {
+    body.classList.add('l-header__menu-open');
+  })
 
+  hide.addEventListener('click', () => {
+    body.classList.remove('l-header__menu-open');
+  })
 
-
+  cover.addEventListener('click', () => {
+    body.classList.remove('l-header__menu-open');
+  })
 }


### PR DESCRIPTION
タブレット用のレイアウトを追加しました。
ハンバーガーメニューの出し入れは`body`に対して`l-header__menu-open`クラスをつけ外しすることで実装しております。